### PR TITLE
tokyorubykaigi12.github.io がホストの時は  regional.rubykaigi.org にリダイレクトさせる

### DIFF
--- a/src/components/Layouts/Head.astro
+++ b/src/components/Layouts/Head.astro
@@ -33,7 +33,7 @@ const { title, twitter_card } = Astro.props;
 />
 
 <script>
-  if (location.host === "osyoyu.github.io") {
+  if (location.host === "tokyorubykaigi12.github.io") {
     location.host = "regional.rubykaigi.org";
   }
 </script>


### PR DESCRIPTION
> osyoyu: tokyorubykaigi12.github.io から regional.rubykaigi.org にリダイレクトするのができてなくて、github.io が露出しうる状態になっちゃってるね

↑を直します。