### PR TITLE
前夜祭のお知らせをNewsに追加する

### DIFF
--- a/src/components/news/List.astro
+++ b/src/components/news/List.astro
@@ -4,6 +4,12 @@ import NewsTemplate from './Template.astro';
 ---
 
 <Panel title="News" subtitle="お知らせ">
+  <NewsTemplate date="2024.12.04">
+    <a href="https://connpass.com/event/339170/">前夜祭の参加受付が始まりました!!</a><br />
+    東京Ruby会議12では本会の前日に前夜祭を開催します!<br />
+    前夜祭は二部構成となっています。第一部はRubyでクリエイティブコーディングを楽しむためのワークショップを開催します。第二部はパーティーセッションとしてプロポーザルを提出いただいた方にご協力いただき発表を行ってもらいます。<br />
+    <a href="https://connpass.com/event/339170/">connpassの募集ページ</a>を公開していますので参加登録をぜひよろしくお願いします!
+  </NewsTemplate>
   <NewsTemplate date="2024.10.23">
     連絡先メールアドレスを新設しました。<br />
     <a href="mailto:team@tokyorubykaigi12.org">team@tokyorubykaigi12.org</a><br />


### PR DESCRIPTION
ref: https://github.com/tokyorubykaigi12/ops/issues/133#issuecomment-2514843327

公開したのでNewsにものせます。
<img width="640" alt="image" src="https://github.com/user-attachments/assets/ed04f51f-e0e4-4e38-975e-f8fdb7ccf565">
