### PR TITLE
switch with tab?

### DIFF
--- a/src/components/talks/Main.astro
+++ b/src/components/talks/Main.astro
@@ -1,13 +1,13 @@
 ---
-import Panel from '../Layouts/Panel.astro';
+import Panel from "../Layouts/Panel.astro";
 
-import TabToggle from './TabToggle';
-import Talks from './Talks';
-import ZenyasaiTalks from './ZenyasaiTalks';
+import TabToggle from "./TabToggle";
+import Talks from "./Talks";
+import ZenyasaiTalks from "./ZenyasaiTalks";
 ---
 
 <Panel title="Talks">
-  <TabToggle client:load/>
-  <Talks client:load />
-  <ZenyasaiTalks client:load/>
+  <TabToggle client:only />
+  <Talks client:only />
+  <ZenyasaiTalks client:only />
 </Panel>

--- a/src/components/talks/tabStore.ts
+++ b/src/components/talks/tabStore.ts
@@ -1,4 +1,16 @@
-import { atom } from 'nanostores';
+import { atom } from "nanostores";
 
-export type Tab = 'fri' | 'sat'
-export const selectedTabStore = atom<Tab>('sat');
+export type Tab = "fri" | "sat";
+
+const urlParams = new URLSearchParams(window.location.search);
+
+function getDefaultValue(): Tab {
+  const value = urlParams.get("tab");
+  if (value !== null && (value === "fri" || value === "sat")) {
+    return value;
+  }
+
+  return "sat";
+}
+
+export const selectedTabStore = atom<Tab>(getDefaultValue());


### PR DESCRIPTION
`/tokyo12/talks?tab=fri` で前夜祭を、`/tokyo12/talks?tab=sat` で当日の talks をデフォルト表示します。

|tab=fri|tab=sat|
|--|--|
|<img width="706" alt="image" src="https://github.com/user-attachments/assets/e3bd4df3-6a91-4395-a393-82646bab0a1c" />|<img width="700" alt="image" src="https://github.com/user-attachments/assets/dc53fc32-5d7e-4077-a54e-c8a643f00bab" />|

ちなみに関係ない値が入ったら当日のやつがデフォルト表示になるます。
<img width="706" alt="image" src="https://github.com/user-attachments/assets/116006a8-04d5-4a6d-9614-36b19d984777" />
